### PR TITLE
docs: correct LICENSE copyright to BChop Studio

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 BChop
+Copyright (c) 2026 BChop Studio
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Corrects the MIT license copyright line from 'BChop' to 'BChop Studio', matching the bchop-studio org convention.